### PR TITLE
Add PostCSS syntax highlighting support. Fixes #10

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,7 @@ from SublimeLinter.lint import Linter, util
 class Stylelint(Linter):
     """Provides an interface to stylelint."""
 
-    syntax = ('css', 'css3', 'sass', 'scss')
+    syntax = ('css', 'css3', 'sass', 'scss', 'postcss')
     cmd = ('node', os.path.dirname(os.path.realpath(__file__)) + '/stylelint_wrapper.js', '@')
     error_stream = util.STREAM_BOTH
     config_file = ('--config', '.stylelintrc')


### PR DESCRIPTION
I've added support for [PostCSS syntax highlighting](https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS).

Sorry, I've not tested this change, but according to [section about linters](http://sublimelinter.readthedocs.org/en/latest/linter_attributes.html#syntax) in SublimeLinter docs this would do the trick.
