### PR TITLE
Use NodeLinter to support local stylelint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --add-ignore=D202

--- a/linter.py
+++ b/linter.py
@@ -9,8 +9,6 @@
 #
 """This module exports the Stylelint plugin class."""
 
-import os
-
 from SublimeLinter.lint import NodeLinter, util
 
 

--- a/linter.py
+++ b/linter.py
@@ -13,6 +13,7 @@ import os
 
 from SublimeLinter.lint import NodeLinter, util
 
+
 class Stylelint(NodeLinter):
     """Provides an interface to stylelint."""
 

--- a/linter.py
+++ b/linter.py
@@ -11,16 +11,31 @@
 
 import os
 
-from SublimeLinter.lint import Linter, util
+from SublimeLinter.lint import NodeLinter, util
 
-class Stylelint(Linter):
+class Stylelint(NodeLinter):
     """Provides an interface to stylelint."""
 
     syntax = ('css', 'css3', 'sass', 'scss', 'postcss')
-    cmd = ('node', os.path.dirname(os.path.realpath(__file__)) + '/stylelint_wrapper.js', '@')
+    executable = 'stylelint'
+    npm_name = 'stylelint'
     error_stream = util.STREAM_BOTH
     config_file = ('--config', '.stylelintrc', '~')
     tempfile_suffix = 'css'
     regex = (
         r'^(?P<line>[0-9]+)\:(?P<col>[0-9]+)(?P<message>.+)'
     )
+
+    def cmd(self):
+        """Return a tuple with the command line to execute."""
+
+        path = self.executable_path
+
+        if not path:
+            result = self.context_sensitive_executable_path([self.executable])
+
+            if result[1]:
+                path = result[1]
+
+        command = [path]
+        return command


### PR DESCRIPTION
I am not really a Python developer, all credit goes to @daniele-rapagnani with this [PR for coffeelint](https://github.com/SublimeLinter/SublimeLinter-coffeelint/pull/24). 

I tried this by myself and it works quite nicely indeed. There is no need for `stylelint_wrapper.js` anymore apparently. Perhaps there are some other cases I am missing here so I don't expect merge right away, but it's a start...
