### PR TITLE
Update sublime linter regex to handle whitespace in stylelint output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --add-ignore=D203

--- a/linter.py
+++ b/linter.py
@@ -22,5 +22,5 @@ class Stylelint(Linter):
     config_file = ('--config', '.stylelintrc', '~')
     tempfile_suffix = 'css'
     regex = (
-        r'^(?P<line>[0-9]+)\:(?P<col>[0-9]+)(?P<message>.+)'
+        r'^\s*(?P<line>[0-9]+)\:(?P<col>[0-9]+)\s*(?P<message>.+)'
     )

--- a/linter.py
+++ b/linter.py
@@ -13,6 +13,7 @@ import os
 
 from SublimeLinter.lint import Linter, util
 
+
 class Stylelint(Linter):
     """Provides an interface to stylelint."""
 


### PR DESCRIPTION
Fixes kungfusheep/SublimeLinter-contrib-stylelint#25
Fixes kungfusheep/SublimeLinter-contrib-stylelint#20

The output of styelint looks like this:

```
    4:5    ✖  Expected indentation of 1 tab                                                    indentation
```

So, the regex now handles the whitespace at beginning of the line and between line number and error.

Props to @Arkkimaagi in #25 for the solution. I updated the regex to use `\s` instead of a space.
