### PR TITLE
fix(stylelint_wrapper): fix cli.js path on Windows

### DIFF
--- a/stylelint_wrapper.js
+++ b/stylelint_wrapper.js
@@ -46,10 +46,11 @@ if (index > -1) {
     /// if we cannot locate a local stylelint CLI, try to look for it on npm global
     if(!cliLocation && !useOld) {
         var npmPath = require("child_process").execSync("npm root -g").toString()
-            .trim().replace("/node_modules", "");
+            .trim();
+        var cliPath = npmPath + CLI_JS_LOCATION.replace("/node_modules", "");
 
-        if(fs.existsSync(npmPath + CLI_JS_LOCATION)) {
-            cliLocation = npmPath + CLI_JS_LOCATION;    
+        if(fs.existsSync(cliPath)) {
+            cliLocation = cliPath;
         }
     }
 }


### PR DESCRIPTION
Windows' directory separators are backslashes like this `\`, trying to replace `/node_modules` would end up with 2 `node_module` directories in the same path failing the conditional.

The original code returned the following path:

```
C:\Users\neojp\AppData\Roaming\npm\node_modules/node_modules/stylelint/dist/cli.js
```

Proposed code returns the following:

```
C:\Users\neojp\AppData\Roaming\npm\node_modules/stylelint/dist/cli.js
```

By failing the conditional `if(cliLocation){` it would attempt to run the else section returning the following error:

```
Error: Cannot find module 'postcss'
```

This fix only applies to global packages.
