### PR TITLE
Add support for handling errors and warnings

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -23,5 +23,5 @@ class Stylelint(Linter):
     config_file = ('--config', '.stylelintrc', '~')
     tempfile_suffix = 'css'
     regex = (
-        r'^\s*(?P<line>[0-9]+)\:(?P<col>[0-9]+)\s*(?P<message>.+)'
+        r'^\s*(?P<line>[0-9]+)\:(?P<col>[0-9]+)\s*(?:(?P<error>✖)|(?P<warning>⚠))\s*(?P<message>.+)'
     )


### PR DESCRIPTION
Currently, linter handles every error as true error, but if you set certain rule to `severity: "warning"`, that rule should be handled as warning and therefore differently marked inside editor. This PR also (probably) fixes https://github.com/kungfusheep/SublimeLinter-contrib-stylelint/issues/22.
