### PR TITLE
Add Vue.js single file component support

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ from SublimeLinter.lint import NodeLinter
 class Stylelint(NodeLinter):
     """Provides an interface to stylelint."""
 
-    syntax = ('css', 'css3', 'sass', 'scss', 'postcss', 'less', 'sugarss', 'sss')
+    syntax = ('css', 'css3', 'sass', 'scss', 'postcss', 'less', 'sugarss', 'sss', 'vue')
     npm_name = 'stylelint'
     cmd = ('stylelint', '--formatter', 'json', '--stdin', '--stdin-filename', '@')
     version_args = '--version'


### PR DESCRIPTION
Hi Pete, thank you for awesome plugin.
I work with Vue.js and also use Stylelint for CSS files. But whenever I mix those, the lint support is gone. I stumbled upon [this comment](https://github.com/kungfusheep/SublimeLinter-contrib-stylelint/issues/46#issuecomment-270943648) by @scottsandersdev and tried what he said. It worked (except as he stated, for the top level components) so I thought it's good to have it on the plugin's source code.
Long story short here is the PR for the linter to support Vue.js single file components as well.
Thanks in advance.