### PR TITLE
Do not override `communicate`

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,9 +10,7 @@
 """This module exports the Stylelint plugin class."""
 
 import json
-import os
 import re
-import sublime
 
 from SublimeLinter.lint import NodeLinter
 
@@ -55,7 +53,7 @@ class Stylelint(NodeLinter):
         try:
             if output and not match:
                 data = json.loads(output)[0]
-        except:
+        except Exception:
             yield (match, 0, None, "Error", "", "Output json data error", None)
 
         if data and 'invalidOptionWarnings' in data:

--- a/linter.py
+++ b/linter.py
@@ -83,32 +83,3 @@ class Stylelint(NodeLinter):
                     yield (True, line, col, type, "", text, None)
 
         return super().find_errors(output)
-
-    def communicate(self, cmd, code=None):
-        """Run an external executable using stdin to pass code and return its output."""
-        if '__RELATIVE_TO_FOLDER__' in cmd:
-
-            relfilename = self.filename
-            window = self.view.window()
-
-            # can't get active folder, it will work only if there is one folder in project
-            if int(sublime.version()) >= 3080 and len(window.folders()) < 2:
-
-                vars = window.extract_variables()
-
-                if 'folder' in vars:
-                    relfilename = os.path.relpath(self.filename, vars['folder'])
-
-            cmd[cmd.index('__RELATIVE_TO_FOLDER__')] = relfilename
-
-        elif not code:
-
-            filename = self.filename
-            fileext = os.path.splitext(filename)
-
-            cmd.append(filename)
-
-            if fileext and not fileext[1:] in self.syntax:
-                cmd.extend('--syntax', 'css')
-
-        return super().communicate(cmd, code)


### PR DESCRIPTION
Hi :wave:!

Generally, overriding `communicate` is discouraged. However, the current implementation is also broken.

- `'__RELATIVE_TO_FOLDER__'` is not used directly, and since SL4 is coming really, really not necessary.

- `elif not code:` matches the empty string. Generally, bc you use STDIN you MUST assume `code` is never `None` here. So, this whole branch should actually never match.

- `os.path.splitext(filename)` actually returns a tuple `(name, ext)`. So the following code throws. The author assumes here it returns just the 'ext'. (So, the correct code would be `_, fileext = os.path.splitext(filename)`, but as I said the whole if branch should be unreachable.

Bug report https://github.com/SublimeLinter/SublimeLinter/issues/1030  